### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pygments~=2.12
 
 tqdm==4.62
 psutil==5.8.0
-numpy==1.18.0
+numpy==1.22.2
 opencv-python>4.5.3.0,<4.5.4.0
 pillow==8.3.1
 scikit-learn==0.24.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.18.0
- [CVE-2021-33430](https://www.oscs1024.com/hd/CVE-2021-33430)


### What did I do？
Upgrade numpy from 1.18.0 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS