### PR TITLE
fix(sec): upgrade tensorflow to 2.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ nvidia-ml-py3
 pywin32==228 ; sys_platform == "win32"
 pynvx==1.0.0 ; sys_platform == "darwin"
 plaidml-keras==0.7.0
-tensorflow==2.2.0
+tensorflow==2.9.1
 typing-extensions
 
 matplotlib == 3.6.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tensorflow 2.2.0
- [CVE-2020-15266](https://www.oscs1024.com/hd/CVE-2020-15266)


### What did I do？
Upgrade tensorflow from 2.2.0 to 2.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS